### PR TITLE
Update CLI.java(大文字小文字表記ゆれの訂正)

### DIFF
--- a/src/main/java/cli/CLI.java
+++ b/src/main/java/cli/CLI.java
@@ -22,8 +22,12 @@ public class CLI implements Runnable {
       // オプションが存在する時だけ変数に入れる
       if (args.length == 2) {
         option = args[1];
+        
+        //オプションの大文字小文字の表記ゆれをなくす
+        option = option.toLowerCase();
+        
       }
-
+      
       // コマンドごとに処理を分岐
       if (option != null && command.equals("get")) {
         int limit = Integer.parseInt(option);


### PR DESCRIPTION
26-27行に追加
optionに値があった時に、大文字の場合apiに対応する値がないため、すべて小文字に変換する処理を追加。