### PR TITLE
getコマンドでポケモンの名前を繰り返し出力できるプログラム

### DIFF
--- a/src/main/java/cli/CLI.java
+++ b/src/main/java/cli/CLI.java
@@ -1,11 +1,13 @@
 package cli;
 
+import java.util.Scanner;
 import cli.commands.get.GetPokeNameList;
-import cli.commands.status.GetPokeStatus;
+// import cli.commands.status.GetPokeStatus;
 import cli.commands.hello.HelloCommand;
 
 public class CLI implements Runnable {
   private String[] args;
+  Scanner sc = new Scanner(System.in);
 
   CLI(String[] args) {
     this.args = args;
@@ -16,28 +18,37 @@ public class CLI implements Runnable {
     try {
       // コマンドを格納(poke get なら get)
       String command = args[0];
-      // オプション格納(poke get 10なら 10)
-      String option = null;
-
-      // オプションが存在する時だけ変数に入れる
-      if (args.length == 2) {
-        option = args[1];
-      }
 
       // コマンドごとに処理を分岐
-      if (option != null && command.equals("get")) {
-        int limit = Integer.parseInt(option);
-        new GetPokeNameList(limit).run();
+      if (command.equals("get")) {
+        /* getコマンドが実行されると整数値を繰り返し入力できるようになる。
+        0以下か1302以降の整数か整数でない値が入力されるとコマンドの実行が終了する。*/
+        while (true){
+          System.out.print("PokeNumber: ");
+          if (sc.hasNextInt()){
+            int GetPokeNum = sc.nextInt();
+            if (GetPokeNum > 0 && GetPokeNum <= 1302){
+              new GetPokeNameList(GetPokeNum).run();
+            } else {
+              System.out.println("get command finish");
+              break;
+            }
+          } else {
+            System.out.println("Input Error!");
+            break;
+          }
+        }
       }
       
-      if (option != null && command.equals("status")) {
-        String name = option;
-        new GetPokeStatus(name).run();
-      }
+      // if (option != null && command.equals("status")) {
+      //   String name = option;
+      //   new GetPokeStatus(name).run();
+      // }
       
       if (command.equals("hello")) {
         new HelloCommand().run();
       }
+      sc.close();
     } catch (Exception e) {
       e.printStackTrace();
     }


### PR DESCRIPTION
getコマンドを実行すると値を入力できるようになり、0以下か1302以降の整数値、数値として扱えない文字列が入力されるまで何度も入力できる処理を実装しました。